### PR TITLE
Copy text to clipboard with */" registers in vim mode

### DIFF
--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -44,6 +44,27 @@
 })(function(CodeMirror) {
   'use strict';
 
+  // from https://hackernoon.com/copying-text-to-clipboard-with-javascript-df4d4988697f
+  function copyToClipboard (str) {
+    var el = document.createElement('textarea');  // Create a <textarea> element
+    el.value = str;                                 // Set its value to the string that you want copied
+    el.setAttribute('readonly', '');                // Make it readonly to be tamper-proof
+    el.style.position = 'absolute';                 
+    el.style.left = '-9999px';                      // Move outside the screen to make it invisible
+    document.body.appendChild(el);                  // Append the <textarea> element to the HTML document
+    const selected =            
+      document.getSelection().rangeCount > 0        // Check if there is any content selected previously
+        ? document.getSelection().getRangeAt(0)     // Store selection if found
+        : false;                                    // Mark as false to know no selection existed before
+    el.select();                                    // Select the <textarea> content
+    document.execCommand('copy');                   // Copy - only works as a result of a user action (e.g. click events)
+    document.body.removeChild(el);                  // Remove the <textarea> element
+    if (selected) {                                 // If a selection existed before copying
+      document.getSelection().removeAllRanges();    // Unselect everything on the HTML document
+      document.getSelection().addRange(selected);   // Restore the original selection
+    }
+  };
+
   var defaultKeymap = [
     // Key to key mapping. This goes first to make it possible to override
     // existing mappings.
@@ -2233,6 +2254,10 @@
         var endPos = vim.visualMode
           ? cursorMin(vim.sel.anchor, vim.sel.head, ranges[0].head, ranges[0].anchor)
           : oldAnchor;
+        if (['+', '*'].indexOf(args.registerName) !== -1) {
+          copyToClipboard(text)
+          cm.focus()
+        }
         vimGlobalState.registerController.pushText(
             args.registerName, 'yank',
             text, args.linewise, vim.visualBlock);


### PR DESCRIPTION
resolves https://github.com/hackmdio/codimd/issues/351

Yank to `*` or `+` register would copy text to clipboard

![codemirror-yank-to-clipboard](https://user-images.githubusercontent.com/4230968/59548958-96cf4100-8f88-11e9-9c21-60c2ddd5a957.gif)