### PR TITLE
WIP: vim surround plugin

### DIFF
--- a/demo/vim.html
+++ b/demo/vim.html
@@ -54,6 +54,8 @@ int getchar(void)
   }
   return (--n >= 0) ? (unsigned char) *bufp++ : EOF;
 }
+
+&lt;div&gt;tag inside&lt;/div&gt;
 </textarea></form>
 <div style="font-size: 13px; width: 300px; height: 30px;">Key buffer: <span id="command-display"></span></div>
 

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -90,6 +90,7 @@
     { keys: 's\'<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\'' } },
     { keys: 's\"<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\"' } },
     { keys: 's\`<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\`' } },
+    { keys: 's\*<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\*' } },
     { keys: 's\(<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\(' } },
     { keys: 's\)<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\)' } },
     { keys: 's\{<character>', type: 'action', forceMatch: true, action: 'vimChangeSurround', actionArgs: { search: '\{' } },
@@ -2833,7 +2834,7 @@
         var openCs = ['{', '(', '[']
         var mirroredPairs = {'(': ')', ')': '(',
                              '[': ']', ']': '[',
-                             '\'': true, '"': true, '`': true};
+                             '\'': true, '"': true, '`': true, '*': true};
         var multilinePairs = { '{': '}', '}': '{' };
 
         function transformCharacterPair (character) {
@@ -2866,10 +2867,19 @@
 
           var inner = lineContent.slice(openIndex + 1, closeIndex + cursor.ch)
 
+          var addSpace = openCs.includes(replaceCharacter)
+
           var openPos = { ch: openIndex, line: cursor.line }
           var closePos = { ch: cursor.ch + closeIndex + 1, line: cursor.line }
 
-          cm.replaceRange(replacePair[0] + inner + replacePair[1], openPos, closePos)
+          var text
+          if (addSpace) {
+            text = replacePair[0] + ' ' + inner + ' ' + replacePair[1]
+          } else {
+            text = replacePair[0] + inner + replacePair[1]
+          }
+
+          cm.replaceRange(text, openPos, closePos)
         }
 
         function replaceMultilineSurround () {

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -52,7 +52,7 @@
     el.style.position = 'absolute';                 
     el.style.left = '-9999px';                      // Move outside the screen to make it invisible
     document.body.appendChild(el);                  // Append the <textarea> element to the HTML document
-    const selected =            
+    var selected =            
       document.getSelection().rangeCount > 0        // Check if there is any content selected previously
         ? document.getSelection().getRangeAt(0)     // Store selection if found
         : false;                                    // Mark as false to know no selection existed before
@@ -2900,7 +2900,7 @@
 
         function replaceMultilineSurround (cm, searchCharacter, replaceCharacter) {
           var tmp = selectCompanionObject(cm, cursor, searchCharacter, true)  
-          const replacePair = transformCharacterPair(replaceCharacter)
+          var replacePair = transformCharacterPair(replaceCharacter)
 
           if (!replacePair) {
             return

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -2842,11 +2842,13 @@
           if (typeof mirroredPairs[character] === 'boolean') {
             openC = closeC = character
           } else {
+            let pairs = mirroredPairs[character] ? mirroredPairs : multilinePairs
+
             if (openCs.includes(character)) {
               openC = character
-              closeC = mirroredPairs[character]
+              closeC = pairs[character]
             } else {
-              openC = mirroredPairs[character]
+              openC = pairs[character]
               closeC = character
             }
           }
@@ -2882,8 +2884,20 @@
           cm.replaceRange(text, openPos, closePos)
         }
 
-        function replaceMultilineSurround () {
-            
+        function replaceCharacterAt (cm, character, position) {
+          var pos = {
+            ch: position.ch + 1,
+            line: position.line
+          }
+          cm.replaceRange(character, position, pos)
+        }
+
+        function replaceMultilineSurround (cm, searchCharacter, replaceCharacter) {
+          var tmp = selectCompanionObject(cm, cursor, searchCharacter, true)  
+          const replacePair = transformCharacterPair(replaceCharacter)
+
+          replaceCharacterAt(cm, replacePair[0], tmp.start)
+          replaceCharacterAt(cm, replacePair[1], { ch: tmp.end.ch - 1, line: tmp.end.line })
         }
 
         if (mirroredPairs[actionArgs.search]) {

--- a/keymap/vim.js
+++ b/keymap/vim.js
@@ -85,7 +85,7 @@
     { keys: '<C-c>', type: 'keyToKey', toKeys: '<Esc>' },
     { keys: '<C-[>', type: 'keyToKey', toKeys: '<Esc>', context: 'insert' },
     { keys: '<C-c>', type: 'keyToKey', toKeys: '<Esc>', context: 'insert' },
-    { keys: 's', type: 'keyToKey', toKeys: 'cl', context: 'normal' },
+    { keys: 's', type: 'keyToKey', toKeys: 'cl', context: 'normal', excludeOperator: ['change'] },
     { keys: 's', type: 'keyToKey', toKeys: 'c', context: 'visual'},
     { keys: 'S', type: 'keyToKey', toKeys: 'cc', context: 'normal' },
     { keys: 'S', type: 'keyToKey', toKeys: 'VdO', context: 'visual' },
@@ -2861,6 +2861,7 @@
         if (context == 'insert' && command.context != 'insert' ||
             command.context && command.context != context ||
             inputState.operator && command.type == 'action' ||
+            (command.excludeOperator && command.excludeOperator.includes(inputState.operator)) ||
             !(match = commandMatch(keys, command.keys))) { continue; }
         if (match == 'partial') { partial.push(command); }
         if (match == 'full') { full.push(command); }


### PR DESCRIPTION
![vim-surround-codemirror](https://user-images.githubusercontent.com/4230968/79007217-49facd80-7b8d-11ea-8e00-61864069b12c.gif)


Spec: https://github.com/tpope/vim-surround/


### TODOs

- [x] change surround `{`
- [x] change surround tag (<kbd>cs'\<q\></kbd>)
- [ ] delete surround (single line quotes)
- [ ] delete surround `{`
- [ ] delete surround tag
- [ ] <kbd>cst"`</kbd>
- [ ] wrap text object surround (<kbd> ysiw]</kbd>
- [ ] wrap entire line (<kbd>yssb</kbd>)
- [ ] linewise visual mode