### PR TITLE
feature/line based chunks

### DIFF
--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -479,15 +479,15 @@
     }
 
     if (offset[0] != offset[1] || cm.length == 3 && offset[1] != offset[2])
-      alignLines(cm, offset, [0, 0, 0], aligners)
+      alignLines(cm, offset, [0, 0, 0], aligners, dv.mv.options.padDirection)
     for (var ln = 0; ln < linesToAlign.length; ln++)
-      alignLines(cm, offset, linesToAlign[ln], aligners);
+      alignLines(cm, offset, linesToAlign[ln], aligners, dv.mv.options.padDirection);
 
     for (var i = 0; i < cm.length; i++)
       cm[i].scrollTo(null, scroll[i]);
   }
 
-  function alignLines(cm, cmOffset, lines, aligners) {
+  function alignLines(cm, cmOffset, lines, aligners, padDirection) {
     var maxOffset = -1e8, offset = [];
     for (var i = 0; i < cm.length; i++) if (lines[i] != null) {
       var off = cm[i].heightAtLine(lines[i], "local") - cmOffset[i];
@@ -496,12 +496,13 @@
     }
     for (var i = 0; i < cm.length; i++) if (lines[i] != null) {
       var diff = maxOffset - offset[i];
-      if (diff > 1 && i === 0) {
-        aligners.push(padAbove(cm[i], lines[i], diff));
-      } else if (diff > 1) {
-        aligners.push(padBelow(cm[i], lines[i] - 1, diff));
-      }
+      if (diff > 1) aligners.push(padAlign(cm[i], lines[i] - 1, diff, padDirection));
     }
+  }
+
+  function padAlign(cm, line, size, padDirection) {
+    if (padDirection === 'below') return padBelow(cm, line, size)
+    return padAbove(cm, line, size)
   }
 
   function padAbove(cm, line, size) {

--- a/addon/merge/merge.js
+++ b/addon/merge/merge.js
@@ -345,7 +345,7 @@
       var ch = dv.chunks[i];
       if (ch.editFrom <= vpEdit.to && ch.editTo >= vpEdit.from &&
           ch.origFrom <= vpOrig.to && ch.origTo >= vpOrig.from)
-        drawConnectorsForChunk(dv, ch, sTopOrig, sTopEdit, w);
+        drawConnectorsForChunk(dv, ch, sTopOrig, sTopEdit, w, i);
     }
   }
 
@@ -524,7 +524,7 @@
     return cm.addLineWidget(line, elt, {height: size, above: false, mergeSpacer: true, handleMouseEvents: true});
   }
 
-  function drawConnectorsForChunk(dv, chunk, sTopOrig, sTopEdit, w) {
+  function drawConnectorsForChunk(dv, chunk, sTopOrig, sTopEdit, w, index) {
     var flip = dv.type == "left";
     var top = dv.orig.heightAtLine(chunk.origFrom, "local", true) - sTopOrig;
     if (dv.svg) {
@@ -552,6 +552,7 @@
       copy.chunk = chunk;
       copy.style.top = (chunk.origTo > chunk.origFrom ? top : dv.edit.heightAtLine(chunk.editFrom, "local") - sTopEdit) + "px";
       copy.setAttribute("role", "button");
+      copy.setAttribute("data-chunk-index", index);
 
       if (editOriginals) {
         var leftButton = typeof dv.getLeftRevertButton === 'function' && dv.getLeftRevertButton("CodeMirror-merge-copy-reverse");
@@ -565,6 +566,7 @@
         copyReverse.style.top = topReverse + "px";
         dv.type == "right" ? copyReverse.style.left = "2px" : copyReverse.style.right = "2px";
         copyReverse.setAttribute("role", "button");
+        copyReverse.setAttribute("data-chunk-index", index);
       }
     }
   }


### PR DESCRIPTION
This PR introduces a new diff mode in the merge view addon, which allows chunks to be applied line by line. And a pad direction setting to allow padding below the chunk.

Example (with `chunkPerLine: true` and `padDirection: 'below'`, please ignore the custom apply chunk button and colors :sweat_smile:):
![image](https://github.com/user-attachments/assets/0de81d33-7c82-4788-810d-1d58ffa7bede)
