### PR TITLE
fix/remove gecko from `captureRightClick`

### DIFF
--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -30,4 +30,4 @@ if (presto_version) presto_version = Number(presto_version[1])
 if (presto_version && presto_version >= 15) { presto = false; webkit = true }
 // Some browsers use the wrong event properties to signal cmd/ctrl on OS X
 export let flipCtrlCmd = mac && (qtwebkit || presto && (presto_version == null || presto_version < 12.11))
-export let captureRightClick = gecko || (ie && ie_version >= 9)
+export let captureRightClick = ie && ie_version >= 9


### PR DESCRIPTION
Newer version of Firefox behaves more like Chrome, where right-click does not trigger a `mouseup` event on `window`. This causes the editor to break since the regular events are always prevented and never restored.

https://github.com/hackmdio/CodeMirror/blob/2b27904616c78d517b7781eaeb0108fddd776461/src/input/TextareaInput.js#L354-L363

In this PR, I've removed gecko from the `captureRightClick` condition check, verified to work on Firefox versions newer than 124.0.1 (2024/03/22, the oldest version I am able to rollback to).