### PR TITLE
fix/inline block mathjax and shell delimiter

### DIFF
--- a/mode/markdown/markdown_math.js
+++ b/mode/markdown/markdown_math.js
@@ -248,7 +248,32 @@ CodeMirror.defineMode("markdown", function(cmCfg, modeCfg) {
       state.code = -1
       return getType(state);
     } else if (firstTokenOnLine && state.indentation <= maxNonCodeIndentation && (match = stream.match(fencedMathRE, true))) {
-      state.fencedEndRE = new RegExp(match[1].replace(/\$/g, '\\$') + "+ *$");
+      // match[0] is the whole line
+      // match[1] is the opening fence "$$"
+      // match[2] is the optional language / mode name
+      var wholeLine = match[0];
+      var openingFence = match[1];
+
+      // Everything after the opening "$$"
+      var rest = wholeLine.slice(openingFence.length);
+
+      // If there's another "$$" in the rest of the line, treat this as
+      // a single-line math block: $$ ... $$.
+      var closingIndex = rest.indexOf("$$");
+
+      if (closingIndex !== -1) {
+        // Single-line $$ ... $$: highlight as math, but do NOT enter
+        // multi-line fenced math mode.
+
+        state.formatting = "math";
+        state.math = 0; // not in a multi-line math block
+        // We've already consumed the whole line via stream.match(..., true)
+        // so just return the math token type for this line.
+        return tokenTypes.math;
+      }
+
+      // Otherwise fall back to the original behavior: multi-line fenced math
+      state.fencedEndRE = new RegExp(openingFence.replace(/\$/g, '\\$') + "+ *$");
       // try switching mode
       state.localMode = modeCfg.fencedCodeBlockHighlighting && getMode(match[2] || modeCfg.fencedCodeBlockDefaultMode );
       if (state.localMode) state.localState = CodeMirror.startState(state.localMode);

--- a/mode/shell/shell.js
+++ b/mode/shell/shell.js
@@ -72,7 +72,7 @@ CodeMirror.defineMode('shell', function() {
     }
     if (ch == "<") {
       if (stream.match("<<")) return "operator"
-      var heredoc = stream.match(/^<-?\s*['"]?([^'"]*)['"]?/)
+      var heredoc = stream.match(/^<-?\s*['"]?([^\s'"]*)['"]?/)
       if (heredoc) {
         state.tokens.unshift(tokenHeredoc(heredoc[1]))
         return 'string-2'


### PR DESCRIPTION
This PR fixes two edge cases:

1. In editor syntax highlighting breaks after block math syntax is being written inline:
	Normal case:
	```
	### Title 1
	$$
	f(y) = x + 1
	$$
	#### Title 2
	```

	Broken case:
	```
	### Title 1 // This is normal
	Test before $$ f(y) = x + 1 $$ Test after
	#### Title 2 // This is not highlighted
	```
2. `EOF` delimiter not being correctly captured in `shell`/`bash` mode code block.
	```
	sudo pacman -Syu
	
	cat <<EOF >> notes.txt
	This will be appended.
	$HOME will literally appear as "$HOME" because of the quotes.
	EOF
	
	pwd # this is treated as part of input to `cat`
	sudo pacman -Syu # this is treated as part of input to `cat`
	```

This branch:

1. <img width="590" height="158" alt="image" src="https://github.com/user-attachments/assets/f2ca3e05-7f7c-46aa-9577-94bf0b654c13" />
2. <img width="548" height="348" alt="image" src="https://github.com/user-attachments/assets/11191404-6143-4b2e-b81c-4c3e25ee6255" />
