### PR TITLE
fix/restore paste on firefox

### DIFF
--- a/src/input/TextareaInput.js
+++ b/src/input/TextareaInput.js
@@ -355,9 +355,14 @@ export default class TextareaInput {
       e_stop(e)
       let mouseup = () => {
         off(window, "mouseup", mouseup)
+        off(window, "contextmenu", mouseup)
         setTimeout(rehide, 20)
       }
       on(window, "mouseup", mouseup)
+      // Modern Firefox doesn't fire mouseup on window when the native
+      // context menu opens, but it fires contextmenu right after the
+      // mousedown that triggered this hack (#27).
+      on(window, "contextmenu", mouseup)
     } else {
       setTimeout(rehide, 50)
     }

--- a/src/util/browser.js
+++ b/src/util/browser.js
@@ -30,4 +30,4 @@ if (presto_version) presto_version = Number(presto_version[1])
 if (presto_version && presto_version >= 15) { presto = false; webkit = true }
 // Some browsers use the wrong event properties to signal cmd/ctrl on OS X
 export let flipCtrlCmd = mac && (qtwebkit || presto && (presto_version == null || presto_version < 12.11))
-export let captureRightClick = ie && ie_version >= 9
+export let captureRightClick = gecko || (ie && ie_version >= 9)


### PR DESCRIPTION
- restore paste in context menu on firefox

before:
<img width="527" height="144" alt="image" src="https://github.com/user-attachments/assets/20eef975-82ca-4cdc-8a88-6b6f90a4c8d1" />
after:
<img width="461" height="356" alt="image" src="https://github.com/user-attachments/assets/0c392396-476f-4a22-bb94-3e3f99ebd5e2" />
